### PR TITLE
WIP Set dynamic role and role-binding

### DIFF
--- a/bundle/manifests/cluster_templates_user_role.yaml
+++ b/bundle/manifests/cluster_templates_user_role.yaml
@@ -12,12 +12,6 @@ rules:
     resources:
       - clustertemplatequotas
   - verbs:
-      - get
-    apiGroups:
-      - ''
-    resources:
-      - secrets
-  - verbs:
       - '*'
     apiGroups:
       - clustertemplate.openshift.io

--- a/controllers/clustertemplateinstance_controller.go
+++ b/controllers/clustertemplateinstance_controller.go
@@ -454,6 +454,48 @@ func (r *ClusterTemplateInstanceReconciler) reconcileClusterCredentials(
 	clusterTemplateInstance.Status.Kubeconfig = &corev1.LocalObjectReference{
 		Name: clusterTemplateInstance.GetKubeconfigRef(),
 	}
+
+	if err := r.reconcileDynamicRoles(ctx, r.Client, clusterTemplateInstance); err != nil {
+		clusterTemplateInstance.Status.Phase = v1alpha1.CredentialsFailedPhase
+		errMsg := fmt.Sprintf("failed to reconcile role and role-bindings for users with cluster-templates-role - %q", err)
+		clusterTemplateInstance.Status.Message = errMsg
+		return fmt.Errorf(errMsg)
+	}
+
+	return nil
+}
+
+func (*ClusterTemplateInstanceReconciler) reconcileDynamicRoles(
+	ctx context.Context,
+	k8sClient client.Client,
+	clusterTemplateInstance *v1alpha1.ClusterTemplateInstance,
+) error {
+	roleSubjects, err := clusterTemplateInstance.GetSubjectsWithClusterTemplateUserRole(ctx, k8sClient)
+	if err != nil {
+		clusterTemplateInstance.Status.Phase = v1alpha1.CredentialsFailedPhase
+		errMsg := fmt.Sprintf("failed to get list of users - %q", err)
+		clusterTemplateInstance.Status.Message = errMsg
+		return fmt.Errorf(errMsg)
+	}
+
+	role, err := clusterTemplateInstance.CreateDynamicRole(ctx, k8sClient,
+		[]string{clusterTemplateInstance.GetKubeadminPassRef(), clusterTemplateInstance.GetKubeconfigRef()})
+
+	if err != nil {
+		clusterTemplateInstance.Status.Phase = v1alpha1.CredentialsFailedPhase
+		errMsg := fmt.Sprintf("failed to create role to access cluster secrets - %q", err)
+		clusterTemplateInstance.Status.Message = errMsg
+		return fmt.Errorf(errMsg)
+	}
+
+	_, err = clusterTemplateInstance.CreateDynamicRoleBinding(ctx, k8sClient, role, roleSubjects)
+	if err != nil {
+		clusterTemplateInstance.Status.Phase = v1alpha1.CredentialsFailedPhase
+		errMsg := fmt.Sprintf("failed to create RoleBinding for %d subjects - %q", len(roleSubjects), err)
+		clusterTemplateInstance.Status.Message = errMsg
+		return fmt.Errorf(errMsg)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
For a deployed cluster (clustertemplateinstance is provided with kubeconfig/password), create
- Role [clustertemplateinstance.name]-role
  - granting access to kubeconfig/password secret
- RoleBinding [clustertemplateinstance.name]-rolebinding
   - binding the new role to all subjects (users, groups) who are bound  to the cluster-temapletes-user cluster role
    
Both new resources have ownerReference set to the  clustertemplateinstance for future clean-up.
