### PR TITLE
Add cluster-templates-user-ct ClusterRole definition

### DIFF
--- a/bundle/manifests/cluster_templates_user_ct_role.yaml
+++ b/bundle/manifests/cluster_templates_user_ct_role.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRole
+metadata:
+  name: cluster-templates-user-ct
+rules:
+- apiGroups:
+  - clustertemplate.openshift.io
+  resources:
+  - clustertemplates
+  verbs:
+  - get
+  - watch
+  - list

--- a/bundle/manifests/cluster_templates_user_role.yaml
+++ b/bundle/manifests/cluster_templates_user_role.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
The role grants permission to list/get ClusterTemplates at cluster scope.

It is an addition to cluster-templates-user cluster role which can be bound by namespaced RoleBining only and is required to create ClusterTemplateInstances by an user.