### PR TITLE
Add option to not create default templates

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the clustertemplate v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=clustertemplate.openshift.io
+// +kubebuilder:object:generate=true
+// +groupName=clustertemplate.openshift.io
 package v1alpha1
 
 import (

--- a/controllers/claas_controller.go
+++ b/controllers/claas_controller.go
@@ -43,9 +43,10 @@ var (
 type CLaaSReconciler struct {
 	Manager ctrl.Manager
 	client.Client
-	enableHypershift    bool
-	enableHive          bool
-	enableConsolePlugin bool
+	enableHypershift       bool
+	enableHive             bool
+	enableConsolePlugin    bool
+	CreateDefaultTemplates bool
 }
 
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
@@ -71,8 +72,9 @@ func (r *CLaaSReconciler) Reconcile(
 		ctiControllerCancel = StartCTIController(r.Manager, r.enableHypershift, r.enableHive)
 
 		if err := (&defaultresources.HypershiftTemplateReconciler{
-			Client: r.Manager.GetClient(),
-			Scheme: r.Manager.GetScheme(),
+			Client:                 r.Manager.GetClient(),
+			Scheme:                 r.Manager.GetScheme(),
+			CreateDefaultTemplates: r.CreateDefaultTemplates,
 		}).SetupWithManager(r.Manager); err != nil {
 			CLaaSlog.Error(err, "unable to create controller", "controller", "HypershiftTemplate")
 			os.Exit(1)
@@ -117,8 +119,9 @@ func (r *CLaaSReconciler) SetupWithManager() error {
 
 	if r.enableHypershift {
 		if err := (&defaultresources.HypershiftTemplateReconciler{
-			Client: client,
-			Scheme: scheme,
+			Client:                 client,
+			Scheme:                 scheme,
+			CreateDefaultTemplates: r.CreateDefaultTemplates,
 		}).SetupWithManager(r.Manager); err != nil {
 			CLaaSlog.Error(err, "unable to create controller", "controller", "HypershiftTemplate")
 			os.Exit(1)

--- a/controllers/defaultresources/hypershifttemplate_controller.go
+++ b/controllers/defaultresources/hypershifttemplate_controller.go
@@ -72,7 +72,8 @@ var defaultTemplates = map[string]*v1alpha1.ClusterTemplate{
 
 type HypershiftTemplateReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme                 *runtime.Scheme
+	CreateDefaultTemplates bool
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -86,11 +87,13 @@ func (r *HypershiftTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Complete(r); err != nil {
 		return fmt.Errorf("failed to construct controller: %w", err)
 	}
-	go func() {
-		for template := range defaultTemplates {
-			initialSync <- event.GenericEvent{Object: defaultTemplates[template]}
-		}
-	}()
+	if r.CreateDefaultTemplates {
+		go func() {
+			for template := range defaultTemplates {
+				initialSync <- event.GenericEvent{Object: defaultTemplates[template]}
+			}
+		}()
+	}
 	return nil
 }
 

--- a/controllers/defaultresources/hypershifttemplate_controller_test.go
+++ b/controllers/defaultresources/hypershifttemplate_controller_test.go
@@ -1,15 +1,50 @@
 package defaultresources
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stolostron/cluster-templates-operator/api/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var _ = Describe("HypershiftTemplate controller", func() {
+
+	var (
+		templateRecon *HypershiftTemplateReconciler
+		err           error
+		cancelContext context.CancelFunc
+		ctx           context.Context
+
+		k8sManager manager.Manager
+	)
+
+	BeforeEach(func() {
+		k8sManager = getK8sManager(cfg)
+
+		templateRecon = &HypershiftTemplateReconciler{
+			Client:                 k8sManager.GetClient(),
+			Scheme:                 k8sManager.GetScheme(),
+			CreateDefaultTemplates: true,
+		}
+		err = templateRecon.SetupWithManager(k8sManager)
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx, cancelContext = context.WithCancel(context.TODO())
+		go func() {
+			err = k8sManager.Start(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+	})
+
+	AfterEach(func() {
+		cancelContext()
+	})
+
 	It("Creates default templates", func() {
 		for template := range defaultTemplates {
 			ct := &v1alpha1.ClusterTemplate{}
@@ -37,6 +72,48 @@ var _ = Describe("HypershiftTemplate controller", func() {
 				Expect(err).Should(BeNil())
 				return ct.Spec.Cost == 1
 			}, timeout, interval).Should(BeTrue())
+		}
+	})
+})
+
+var _ = Describe("HypershiftTemplate controller default template", func() {
+
+	var (
+		templateRecon *HypershiftTemplateReconciler
+		err           error
+		cancelContext context.CancelFunc
+		ctx           context.Context
+
+		k8sManager manager.Manager
+	)
+
+	BeforeEach(func() {
+		k8sManager = getK8sManager(cfg)
+
+		templateRecon = &HypershiftTemplateReconciler{
+			Client:                 k8sManager.GetClient(),
+			Scheme:                 k8sManager.GetScheme(),
+			CreateDefaultTemplates: false,
+		}
+		err = templateRecon.SetupWithManager(k8sManager)
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx, cancelContext = context.WithCancel(context.TODO())
+		go func() {
+			err = k8sManager.Start(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+	})
+
+	AfterEach(func() {
+		cancelContext()
+	})
+
+	It("Don't create default templates", func() {
+		for template := range defaultTemplates {
+			ct := &v1alpha1.ClusterTemplate{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: template}, ct)
+			Expect(err).Should(HaveOccurred())
 		}
 	})
 })

--- a/controllers/defaultresources/suite_test.go
+++ b/controllers/defaultresources/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package defaultresources
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	argo "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -47,8 +47,6 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
 
 const (
 	timeout  = time.Second * 10
@@ -66,8 +64,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	ctx, cancel = context.WithCancel(context.TODO())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -102,29 +98,21 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             scheme.Scheme,
-		MetricsBindAddress: "0",
-	})
-	Expect(err).ToNot(HaveOccurred())
-
-	err = (&HypershiftTemplateReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
 }, 60)
 
 var _ = AfterSuite(func() {
-	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+func getK8sManager(cfg *rest.Config) manager.Manager {
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		MetricsBindAddress: "0",
+		Scheme:             scheme.Scheme,
+	})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	return k8sManager
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strconv"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -138,8 +139,9 @@ func main() {
 	}
 
 	if err = (&controllers.CLaaSReconciler{
-		Client:  mgr.GetClient(),
-		Manager: mgr,
+		Client:                 mgr.GetClient(),
+		Manager:                mgr,
+		CreateDefaultTemplates: getBoolEnv("CREATE_DEFAULT_TEMPLATES", true),
 	}).SetupWithManager(); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CLaaS")
 		os.Exit(1)
@@ -183,4 +185,15 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func getBoolEnv(envName string, defaultVal bool) bool {
+	var err error
+	boolVal := defaultVal
+	if envValue, present := os.LookupEnv(envName); present {
+		if boolVal, err = strconv.ParseBool(envValue); err != nil {
+			return boolVal
+		}
+	}
+	return boolVal
 }


### PR DESCRIPTION
This patch add an option to not create default templates. The ENV variable called CREATE_DEFAULT_TEMPLATES can be set to false, and the default templates won't be created. The default value is 'true'.

Fixes: https://github.com/stolostron/cluster-templates-operator/issues/83

Signed-off-by: Ondra Machacek <omachace@redhat.com>