### PR TITLE
Update Application naming logic

### DIFF
--- a/controllers/clustertemplateinstance_controller.go
+++ b/controllers/clustertemplateinstance_controller.go
@@ -325,6 +325,7 @@ func getClusterProperties(clusterTemplate client.Object) (bool, string, []string
 	case *v1alpha1.ClusterTemplate:
 		skipClusterRegistration = clusterTemplate.(*v1alpha1.ClusterTemplate).Spec.SkipClusterRegistration
 		clusterDefinition = clusterTemplate.(*v1alpha1.ClusterTemplate).Spec.ClusterDefinition
+		clusterSetup = clusterTemplate.(*v1alpha1.ClusterTemplate).Spec.ClusterSetup
 	}
 
 	return skipClusterRegistration, clusterDefinition, clusterSetup


### PR DESCRIPTION
Day1 naming scheme 
<CTI.UID> -  The previous naming was causing issues with resource name being too long

Day2 naming scheme
<CTI.UID-AppSet.Name>

Fix day2 for gitops use-case - Previously the helm params were added also for non-helm AppSet which caused errors in executing such AppSet.