### PR TITLE
Add instance_ns variable to application set

### DIFF
--- a/api/v1alpha1/clustertemplateinstance_utils.go
+++ b/api/v1alpha1/clustertemplateinstance_utils.go
@@ -174,9 +174,9 @@ func (i *ClusterTemplateInstance) UpdateApplicationSet(
 		name = name + "-" + appSet.Name
 	}
 
-	defaultUrl, _ := json.Marshal(map[string]string{"url": server})
+	elements, _ := json.Marshal(map[string]string{"url": server, "instance_ns": i.Namespace})
 	gen := argo.ApplicationSetGenerator{List: &argo.ListGenerator{
-		Elements: []apiextensionsv1.JSON{{Raw: defaultUrl}},
+		Elements: []apiextensionsv1.JSON{{Raw: elements}},
 		Template: argo.ApplicationSetTemplate{
 			ApplicationSetTemplateMeta: argo.ApplicationSetTemplateMeta{
 				Name: name,

--- a/api/v1alpha1/clustertemplateinstance_utils_test.go
+++ b/api/v1alpha1/clustertemplateinstance_utils_test.go
@@ -369,7 +369,7 @@ var _ = Describe("ClusterTemplateInstance utils", func() {
 
 		s, err := a.Items[0].Spec.Generators[0].List.Elements[0].MarshalJSON()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(string(s)).To(ContainSubstring("kubernetes.default.svc"))
+		Expect(string(s)).To(ContainSubstring("{\"instance_ns\":\"default\",\"url\":\"https://kubernetes.default.svc\"}"))
 	})
 
 	It("CreateDay2Applications", func() {


### PR DESCRIPTION
This patch add instance_ns variable to application set, which will replace the variable with CTI namespace.

Fixes: https://github.com/stolostron/cluster-templates-operator/issues/138