### PR TITLE
Updated docs to reflect the new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,14 @@ Install the Cluster as a service operator from the OperatorHub:
 3. In the menu select Operators -> OperatorHub
 4. Search for `Cluster as a service operator`
 5. Select it and hit install button
+6. The UI is installed but not enabled by default. To enable go to `Home` -> `Overview` -> in the status card click `Dynamic Plugins` -> click `View all` -> click the `pencil` icon -> pick `Enable` and hit `Save`
+7. Wait until the UI notifies you to refresh the web console. 
+8. You can access the UI by picking `All Clusters` in the top left corner and go to `Infrastructure` -> `Cluster templates`
 
 Note that ArgoCD is installed as dependency of the operator.
 
 ### Non OCP cluster
 Please follow the instructions from the OperatorHub page (https://operatorhub.io/operator/cluster-aas-operator).
-
-## ArgoCD configuration
-As noted above ArgoCD is installed as a depency of the cluster as a service operator, but it's not configured to be used with the operator.
-Please follow [ArgoCD configuration](./docs/argo.md) to setup ArgoCD.
 
 # How to use
 Cluster as a service operator comes with a few ready-to-be-used templates.
@@ -82,7 +81,7 @@ stringData:
 
 ```
 
- 3. Allow to create the template in this namespace
+ 3. (Optional) Allow to create the template in this namespace
 ```yaml
 apiVersion: clustertemplate.openshift.io/v1alpha1
 kind: ClusterTemplateQuota
@@ -156,7 +155,7 @@ stringData:
 
 ```
 
- 3. Allow to create the template in this namespace
+ 3. (Optional) Allow to create the template in this namespace
 ```yaml
 apiVersion: clustertemplate.openshift.io/v1alpha1
 kind: ClusterTemplateQuota

--- a/bundle/manifests/cluster-aas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-aas-operator.clusterserviceversion.yaml
@@ -124,6 +124,9 @@ spec:
     **Self-service clusters with guardrails!**
     Cluster as a service operator provides an easy way to define clusters as templates and allows creating instances of those templates even for non-privileged developer/devops engineers. Cluster templates operator also allows specifing quotas for the developer/devops engineers.
 
+    ### User Interface
+    The User interface is installed but is not enabled by default. To enable go to `Home` -> `Overview` -> in the status card click `Dynamic Plugins` -> click `View all` -> click the `pencil` icon -> pick `Enable` and hit `Save`. You can access the UI in the `All Clusters` perspective under `Infrastructure` -> `Cluster Templates`.
+
     ### Documentation
     Documentation can be found on our [website](https://github.com/stolostron/cluster-templates-operator).
 

--- a/config/manifests/bases/cluster-aas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-aas-operator.clusterserviceversion.yaml
@@ -89,6 +89,9 @@ spec:
     **Self-service clusters with guardrails!**
     Cluster as a service operator provides an easy way to define clusters as templates and allows creating instances of those templates even for non-privileged developer/devops engineers. Cluster templates operator also allows specifing quotas for the developer/devops engineers.
 
+    ### User Interface
+    The User interface is installed but is not enabled by default. To enable go to `Home` -> `Overview` -> in the status card click `Dynamic Plugins` -> click `View all` -> click the `pencil` icon -> pick `Enable` and hit `Save`. You can access the UI in the `All Clusters` perspective under `Infrastructure` -> `Cluster Templates`.
+
     ### Documentation
     Documentation can be found on our [website](https://github.com/stolostron/cluster-templates-operator).
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,6 +14,10 @@ Resource Types:
 
 - [ClusterTemplate](#clustertemplate)
 
+- [ClusterTemplateSetup](#clustertemplatesetup)
+
+- [Config](#config)
+
 
 
 
@@ -94,6 +98,13 @@ Represents instance of a cluster
           A reference to ClusterTemplate which will be used for installing and setting up the cluster<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>kubeconfigSecretRef</b></td>
+        <td>string</td>
+        <td>
+          A reference to a secret which contains kubeconfig of the cluster. If specified day1 operation won't be executed.<br/>
+        </td>
+        <td>false</td>
       </tr><tr>
         <td><b><a href="#clustertemplateinstancespecparametersindex">parameters</a></b></td>
         <td>[]object</td>
@@ -205,17 +216,10 @@ Represents instance of a cluster
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>clusterTemplateLabels</b></td>
-        <td>map[string]string</td>
+        <td><b><a href="#clustertemplateinstancestatusclustersetupsecretsindex">clusterSetupSecrets</a></b></td>
+        <td>[]object</td>
         <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#clustertemplateinstancestatusclustertemplatespec">clusterTemplateSpec</a></b></td>
-        <td>object</td>
-        <td>
-          <br/>
+          Secrets create by cluster setup which provide crenderntials for applications created by cluster setup<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -367,12 +371,12 @@ A reference for secret which contains username and password under keys "username
 </table>
 
 
-### ClusterTemplateInstance.status.clusterTemplateSpec
+### ClusterTemplateInstance.status.clusterSetupSecrets[index]
 <sup><sup>[↩ Parent](#clustertemplateinstancestatus)</sup></sup>
 
 
 
-
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
 
 <table>
     <thead>
@@ -384,33 +388,10 @@ A reference for secret which contains username and password under keys "username
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>clusterDefinition</b></td>
+        <td><b>name</b></td>
         <td>string</td>
         <td>
-          ArgoCD applicationset name which is used for installation of the cluster<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>clusterSetup</b></td>
-        <td>[]string</td>
-        <td>
-          Array of ArgoCD applicationset names which are used for post installation setup of the cluster<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>cost</b></td>
-        <td>integer</td>
-        <td>
-          Cost of the cluster, used for quotas<br/>
-          <br/>
-            <i>Minimum</i>: 0<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>skipClusterRegistration</b></td>
-        <td>boolean</td>
-        <td>
-          Skip the registeration of the cluster to the hub cluster<br/>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -873,6 +854,255 @@ Describes helm chart properties and their schema
         <td>string</td>
         <td>
           Content of helm chart values.yaml<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+## ClusterTemplateSetup
+<sup><sup>[↩ Parent](#clustertemplateopenshiftiov1alpha1 )</sup></sup>
+
+
+
+
+
+
+Template of a cluster - post-install setup are defined as ArgoCD application set refs.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+      <td><b>apiVersion</b></td>
+      <td>string</td>
+      <td>clustertemplate.openshift.io/v1alpha1</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b>kind</b></td>
+      <td>string</td>
+      <td>ClusterTemplateSetup</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td>object</td>
+      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
+      <td>true</td>
+      </tr><tr>
+        <td><b><a href="#clustertemplatesetupspec">spec</a></b></td>
+        <td>object</td>
+        <td>
+          <br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b><a href="#clustertemplatesetupstatus">status</a></b></td>
+        <td>object</td>
+        <td>
+          ClusterTemplateStatus defines the observed state of ClusterTemplateSetup<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### ClusterTemplateSetup.spec
+<sup><sup>[↩ Parent](#clustertemplatesetup)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>clusterSetup</b></td>
+        <td>[]string</td>
+        <td>
+          Array of ArgoCD applicationset names which are used for post installation setup of the cluster<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>skipClusterRegistration</b></td>
+        <td>boolean</td>
+        <td>
+          Skip the registeration of the cluster to the hub cluster<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### ClusterTemplateSetup.status
+<sup><sup>[↩ Parent](#clustertemplatesetup)</sup></sup>
+
+
+
+ClusterTemplateStatus defines the observed state of ClusterTemplateSetup
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#clustertemplatesetupstatusclustersetupindex">clusterSetup</a></b></td>
+        <td>[]object</td>
+        <td>
+          Describes helm chart properties and schema for every cluster setup step<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### ClusterTemplateSetup.status.clusterSetup[index]
+<sup><sup>[↩ Parent](#clustertemplatesetupstatus)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>
+          Name of the cluster setup step<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>error</b></td>
+        <td>string</td>
+        <td>
+          Contain information about failure during fetching helm chart<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>schema</b></td>
+        <td>string</td>
+        <td>
+          Content of helm chart values.schema.json<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>string</td>
+        <td>
+          Content of helm chart values.yaml<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+## Config
+<sup><sup>[↩ Parent](#clustertemplateopenshiftiov1alpha1 )</sup></sup>
+
+
+
+
+
+
+Configuration of the cluster operator
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+      <td><b>apiVersion</b></td>
+      <td>string</td>
+      <td>clustertemplate.openshift.io/v1alpha1</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b>kind</b></td>
+      <td>string</td>
+      <td>Config</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td>object</td>
+      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
+      <td>true</td>
+      </tr><tr>
+        <td><b><a href="#configspec">spec</a></b></td>
+        <td>object</td>
+        <td>
+          <br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### Config.spec
+<sup><sup>[↩ Parent](#config)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>argoCDNamespace</b></td>
+        <td>string</td>
+        <td>
+          ArgoCd namespace where the ArgoCD instance is running<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>uiEnabled</b></td>
+        <td>boolean</td>
+        <td>
+          Flag that indicate if UI console plugin should be deployed<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>uiImage</b></td>
+        <td>string</td>
+        <td>
+          Custom UI image<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/docs/custom-config.md
+++ b/docs/custom-config.md
@@ -1,6 +1,7 @@
 # Custom configuration
-CaaS can be further customized using the following config map with name **claas-config** in a namespace **cluster-aas-operator**.
-The configurations available for this config map are:
- - argocd-ns: The name of the namespace in which the argocd is running. Default: argocd
- - enable-ui: If true, the UI will be automatically installed. Default: false
- - ui-image: A link to a repository containing the image of the UI. Default: quay.io/stolostron/cluster-templates-console-plugin:latest
+CaaS can be further customized using the Config CR **config.clustertemplate.openshift.io** called **config**. You can edit it by: `oc edit config.clustertemplate.openshift.io config`.
+
+The following configurations are available:
+ - argoCDNamespace: The name of the namespace in which the argocd is running. Default: cluster-aas-operator. **Please note**: after changing this namespace, you have to restart the claas operator (called cluster-aas-operator-controller-manager).
+ - uiEnabled: If true, the UI will be automatically installed. Default: true
+ - uiImage: A link to a repository containing the image of the UI. Default: depends on the version


### PR DESCRIPTION
Updated the install/prereq part as well as regenerated the api reference by:
1: install https://github.com/fybrik/crdoc
2: checkout cluster-templates-operator
3: run /crdoc --resources <caas location>cluster-templates-operator/config/crd/bases --output api-reference.md