### PR TITLE
Preserve ApplicationSet template finalizers

### DIFF
--- a/api/v1alpha1/clustertemplateinstance_utils.go
+++ b/api/v1alpha1/clustertemplateinstance_utils.go
@@ -237,6 +237,9 @@ func (i *ClusterTemplateInstance) labelDestionationNamespace(ctx context.Context
 	}
 
 	if l, lOk := ns.Labels["argocd.argoproj.io/managed-by"]; !lOk || l != argoCDNamespace {
+		if ns.Labels == nil {
+			ns.Labels = map[string]string{}
+		}
 		ns.Labels["argocd.argoproj.io/managed-by"] = argoCDNamespace
 		if err := k8sClient.Update(ctx, ns); err != nil {
 			return err

--- a/api/v1alpha1/clustertemplateinstance_utils_test.go
+++ b/api/v1alpha1/clustertemplateinstance_utils_test.go
@@ -354,7 +354,13 @@ var _ = Describe("ClusterTemplateInstance utils", func() {
 				Name:      "foo",
 				Namespace: "cluster-aas-operator",
 			},
-			Spec: argo.ApplicationSetSpec{},
+			Spec: argo.ApplicationSetSpec{
+				Template: argo.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argo.ApplicationSetTemplateMeta{
+						Finalizers: []string{"fooFinalizer"},
+					},
+				},
+			},
 		}
 
 		client := fake.NewFakeClientWithScheme(scheme.Scheme, appset)
@@ -367,6 +373,8 @@ var _ = Describe("ClusterTemplateInstance utils", func() {
 
 		Expect(len(a.Items[0].Spec.Generators)).To(Equal(1))
 		Expect(len(a.Items[0].Spec.Generators[0].List.Elements)).To(Equal(1))
+		Expect(len(a.Items[0].Spec.Generators[0].List.Template.Finalizers)).To(Equal(2))
+		Expect(a.Items[0].Spec.Generators[0].List.Template.Finalizers).To(Equal([]string{"fooFinalizer", argo.ResourcesFinalizerName}))
 
 		s, err := a.Items[0].Spec.Generators[0].List.Elements[0].MarshalJSON()
 		Expect(err).ToNot(HaveOccurred())
@@ -418,6 +426,9 @@ var _ = Describe("ClusterTemplateInstance utils", func() {
 			Spec: argo.ApplicationSetSpec{
 				Generators: []argo.ApplicationSetGenerator{{}},
 				Template: argo.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argo.ApplicationSetTemplateMeta{
+						Finalizers: []string{argo.ResourcesFinalizerName},
+					},
 					Spec: argo.ApplicationSpec{
 						Source: argo.ApplicationSource{},
 					},
@@ -435,6 +446,7 @@ var _ = Describe("ClusterTemplateInstance utils", func() {
 		//Expect(appsets.Items[0].Spec.Generators[0].String()).To(Equal(""))
 		Expect(len(appsets.Items[0].Spec.Generators)).To(Equal(2))
 		Expect(len(appsets.Items[0].Spec.Generators[1].List.Elements)).To(Equal(1))
+		Expect(len(appsets.Items[0].Spec.Generators[1].List.Template.Finalizers)).To(Equal(0))
 
 		data, err = appsets.Items[0].Spec.Generators[1].List.Elements[0].MarshalJSON()
 		Expect(err).ShouldNot(HaveOccurred())

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/backplane-operator v0.0.0-20220727154840-1f60baf1fb98
 	github.com/stolostron/klusterlet-addon-controller v0.0.0-20230220122621-1dc02f9d616c
+	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.9.4
@@ -239,11 +240,10 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
-	golang.org/x/exp v0.0.0-20210901193431-a062eea981d2 // indirect
 	golang.org/x/image v0.0.0-20191206065243-da761ea9ff43 // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/term v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1262,8 +1262,9 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20210220032938-85be41e4509f/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
-golang.org/x/exp v0.0.0-20210901193431-a062eea981d2 h1:Or4Ra3AAlhUlNn8WmIzw2Yq2vUHSkrP6E2e/FIESpF8=
 golang.org/x/exp v0.0.0-20210901193431-a062eea981d2/go.mod h1:a3o/VtDNHN+dCVLEpzjjUHOzR+Ln3DHX056ZPzoZGGA=
+golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f h1:99ci1mjWVBWwJiEKYY6jWa4d2nTQVIEhZIptnrVb1XY=
+golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f/go.mod h1:/lliqkxwWAhPjf5oSOIJup2XcqJaw8RGS6k3TGEc7GI=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -1403,8 +1404,9 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
These changes:
1. Make it possible for ClusterTemplate admins to implement workarounds involving ArgoCD finalizers, specifically https://github.com/argoproj/argo-cd/issues/17181#issuecomment-2070372558.
2. Fix a minor bug that was causing one of the test cases to consistently fail